### PR TITLE
Add image infrastructure for repository branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<div align="center">
+
+![StyleyeS Banner](images/styleyes-banner.png)
+
+</div>
+
 # StyleyeS
 
 **Vivid Prompt Engineering for AI Image Generation**

--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,87 @@
+# Images Setup Instructions
+
+This directory contains the visual assets for the StyleyeS repository.
+
+## Required Images
+
+### 1. Documentation Banner (`styleyes-banner.png`)
+**Location:** `images/styleyes-banner.png`
+
+This is the simple, clean banner image used in the README documentation.
+
+**Specifications:**
+- Simple dark background with the StyleyeS logo
+- "VASEY/AI PRESENTS" header text
+- Eye icon with gradient colors (orange to pink/purple)
+- "StyleyeS v1.5" title with gradient text
+- Tagline: "The vivid prompt engineering studio."
+- Recommended dimensions: 1920x1080 or similar 16:9 ratio
+
+**Current Status:** ⚠️ NEEDS TO BE ADDED
+- Save the first image you have as `styleyes-banner.png` in this directory
+
+### 2. Repository Cover Image (`styleyes-cover.png`)
+**Location:** `images/styleyes-cover.png`
+
+This is the elaborate, eye-catching cover image for the GitHub repository social preview.
+
+**Specifications:**
+- Cosmic/tech background with orange, pink, and purple color scheme
+- Particles and light effects
+- UI mockup elements visible in the background
+- Same branding elements as banner (logo, title, tagline)
+- More visually rich and detailed than the banner
+- Recommended dimensions: 1280x640 (GitHub's social preview ratio)
+
+**Current Status:** ⚠️ NEEDS TO BE ADDED
+- Save the second image you have as `styleyes-cover.png` in this directory
+
+## Setup Steps
+
+### Step 1: Add the Images to This Directory
+
+1. Save your first image (simple banner) as:
+   ```
+   images/styleyes-banner.png
+   ```
+
+2. Save your second image (elaborate cover) as:
+   ```
+   images/styleyes-cover.png
+   ```
+
+### Step 2: Set Up GitHub Repository Social Preview
+
+The cover image needs to be set as the repository's social preview image on GitHub:
+
+1. Go to your repository on GitHub: `https://github.com/SeanVasey/StyleyeS`
+2. Click **Settings** (repository settings, not personal settings)
+3. Scroll down to the **Social preview** section
+4. Click **Edit** or **Upload an image**
+5. Upload `images/styleyes-cover.png`
+6. The image will now appear when you share the repository on social media, GitHub feeds, etc.
+
+**Note:** The social preview image is separate from the README banner. The banner appears in the README, while the social preview appears on GitHub's repository page and when sharing links.
+
+### Step 3: Verify
+
+After adding the images and pushing to GitHub:
+
+1. Check that the banner appears at the top of the README
+2. Verify the social preview by viewing your repository on GitHub
+3. Share the repository link to see the cover image in the preview
+
+## Image Format Notes
+
+- **PNG format** is recommended for best quality with transparency support
+- **JPG/JPEG** can be used if file size is a concern
+- Ensure images are optimized for web (not too large in file size)
+- GitHub has a 10MB limit for social preview images
+
+## Need Help?
+
+If the images don't appear:
+- Check that the file names match exactly (case-sensitive)
+- Verify the images are in the correct directory
+- Ensure the files are committed and pushed to GitHub
+- Clear your browser cache if the old preview is cached


### PR DESCRIPTION
- Create images directory for visual assets
- Update README with banner image reference
- Add comprehensive setup instructions for images
- Prepare for documentation banner and social preview cover

The README now includes a banner image placeholder that will display
the StyleyeS branding once the image files are added. Detailed
instructions are provided in images/README.md for adding both the
documentation banner and repository cover artwork.