### PR TITLE
fix: address 4 bug issues (#28, #29, #30, #31)

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -2141,12 +2141,21 @@ h3 .section-icon {
 }
 
 /* Success toast - check icon */
-.toast[style*="--success"]::before,
-.toast:not([style*="--warn"])::before {
+.toast.success {
+  border-color: var(--success);
+  color: var(--success);
+}
+
+.toast.success::before {
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='none' stroke='%234ade80' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' xmlns='http://www.w3.org/2000/svg'%3E%3Cpolyline points='20 6 9 17 4 12'/%3E%3C/svg%3E");
 }
 
 /* Warning toast - warning icon */
-.toast[style*="--warn"]::before {
+.toast.warn {
+  border-color: var(--warn);
+  color: var(--warn);
+}
+
+.toast.warn::before {
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='none' stroke='%23fbbf24' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z'/%3E%3Cline x1='12' y1='9' x2='12' y2='13'/%3E%3Cline x1='12' y1='17' x2='12.01' y2='17'/%3E%3C/svg%3E");
 }

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -10,19 +10,25 @@ const StyleyeSCarousel = {
 
   // Configuration
   config: {
-    radius: 220,              // Cylinder radius (px) - tuned for card widths
-    friction: 0.92,           // Velocity decay per frame
-    snapThreshold: 0.12,      // Velocity below which snap begins
-    sensitivity: 0.4,         // Degrees per pixel dragged
-    maxVelocity: 20,          // Clamp throw speed
-    snapEasing: 0.1,          // Lerp factor for snap
+    radius: 220,                      // Cylinder radius (px) - tuned for card widths
+    friction: 0.92,                   // Velocity decay per frame
+    snapThreshold: 0.12,              // Velocity below which snap begins
+    sensitivity: 0.4,                 // Degrees per pixel dragged
+    maxVelocity: 20,                  // Clamp throw speed
+    snapEasing: 0.1,                  // Lerp factor for snap
+
+    // Physics thresholds
+    snapFinalizeThreshold: 0.05,      // Delta below which snap finalizes
+    minAnimationVelocity: 0.01,       // Velocity below which animation stops
+    velocityFrameMultiplier: 16,      // Normalizes velocity to ~60fps (1000ms/60fps ≈ 16ms)
+    programmaticRotationFactor: 0.12, // Velocity factor for rotateTo()
 
     // Depth visual treatment
-    minScale: 0.65,           // Scale at back
-    maxScale: 1.0,            // Scale at front
-    minOpacity: 0.35,         // Opacity at back
-    maxBlur: 3,               // Blur (px) at back
-    zThreshold: -0.2          // Z below which pointer-events disabled
+    minScale: 0.65,                   // Scale at back
+    maxScale: 1.0,                    // Scale at front
+    minOpacity: 0.35,                 // Opacity at back
+    maxBlur: 3,                       // Blur (px) at back
+    zThreshold: -0.2                  // Z below which pointer-events disabled
   },
 
   // Per-carousel state (keyed by category)
@@ -118,7 +124,7 @@ const StyleyeSCarousel = {
    * @param {Function} onUpdate - Update callback
    */
   runPhysics(state, onUpdate) {
-    const { friction, snapThreshold, snapEasing } = this.config;
+    const { friction, snapThreshold, snapEasing, snapFinalizeThreshold, minAnimationVelocity } = this.config;
 
     // Apply friction
     state.velocity *= friction;
@@ -131,7 +137,7 @@ const StyleyeSCarousel = {
       const delta = target - state.rotation;
 
       // Close enough? Finalize.
-      if (Math.abs(delta) < 0.05) {
+      if (Math.abs(delta) < snapFinalizeThreshold) {
         state.rotation = target;
         state.velocity = 0;
         state.isAnimating = false;
@@ -147,7 +153,7 @@ const StyleyeSCarousel = {
     onUpdate(state, false);
 
     // Continue if still moving
-    if (Math.abs(state.velocity) > 0.01 || state.isAnimating) {
+    if (Math.abs(state.velocity) > minAnimationVelocity || state.isAnimating) {
       const rafId = requestAnimationFrame(() => this.runPhysics(state, onUpdate));
       this.rafIds.set(state.categoryId, rafId);
     }
@@ -190,16 +196,16 @@ const StyleyeSCarousel = {
   moveDrag(state, clientX, onUpdate) {
     if (!state.isDragging) return;
 
-    const { sensitivity } = this.config;
+    const { sensitivity, velocityFrameMultiplier } = this.config;
     const deltaX = clientX - state.dragStartX;
     state.rotation = state.dragStartRotation + (deltaX * sensitivity);
 
-    // Calculate velocity
+    // Calculate velocity (normalized to ~60fps using velocityFrameMultiplier)
     const now = performance.now();
     const dt = now - state.lastTime;
     if (dt > 0) {
       const dx = clientX - state.lastX;
-      state.velocity = (dx * sensitivity) * (16 / dt);
+      state.velocity = (dx * sensitivity) * (velocityFrameMultiplier / dt);
     }
 
     state.lastX = clientX;
@@ -233,6 +239,7 @@ const StyleyeSCarousel = {
    * @param {Function} onUpdate - Update callback
    */
   rotateTo(state, targetIndex, onUpdate) {
+    const { programmaticRotationFactor } = this.config;
     targetIndex = ((targetIndex % state.itemCount) + state.itemCount) % state.itemCount;
     const targetRot = -targetIndex * state.anglePerItem;
 
@@ -242,7 +249,7 @@ const StyleyeSCarousel = {
     while (delta > 180) delta -= 360;
     while (delta < -180) delta += 360;
 
-    state.velocity = delta * 0.12;
+    state.velocity = delta * programmaticRotationFactor;
     state.isAnimating = true;
 
     this.cancelAnimation(state.categoryId);

--- a/js/icons.js
+++ b/js/icons.js
@@ -123,6 +123,7 @@ const StyleyeSIcons = {
   }
 };
 
-// Freeze the icons object to prevent modifications
+// Freeze the icons object and nested maps to prevent modifications
 Object.freeze(StyleyeSIcons.categoryMap);
 Object.freeze(StyleyeSIcons.controlCategoryMap);
+Object.freeze(StyleyeSIcons);

--- a/js/ui.js
+++ b/js/ui.js
@@ -849,48 +849,54 @@ const StyleyeSUI = {
       this.updateCarouselCards(track, state);
       this.updateCarouselArrows(prevBtn, nextBtn, state);
 
-      // Mouse events
+      // Mouse events - attach document listeners dynamically to prevent memory leaks
       track.addEventListener('mousedown', (e) => {
         if (e.target.closest('.card-fav')) return; // Don't drag on fav button
         e.preventDefault();
         StyleyeSCarousel.startDrag(state, e.clientX);
         track.style.cursor = 'grabbing';
-      });
 
-      // Use bound handlers for document events to allow cleanup
-      const handleMouseMove = (e) => {
-        if (state.isDragging) {
-          StyleyeSCarousel.moveDrag(state, e.clientX, onUpdate);
-        }
-      };
+        // Define handlers scoped to this drag operation
+        const handleMouseMove = (moveEvent) => {
+          StyleyeSCarousel.moveDrag(state, moveEvent.clientX, onUpdate);
+        };
 
-      const handleMouseUp = () => {
-        if (state.isDragging) {
+        const handleMouseUp = () => {
           StyleyeSCarousel.endDrag(state, onUpdate);
           track.style.cursor = 'grab';
-        }
-      };
+          // Clean up listeners when drag ends
+          document.removeEventListener('mousemove', handleMouseMove);
+          document.removeEventListener('mouseup', handleMouseUp);
+        };
 
-      document.addEventListener('mousemove', handleMouseMove);
-      document.addEventListener('mouseup', handleMouseUp);
+        // Attach listeners only during active drag
+        document.addEventListener('mousemove', handleMouseMove);
+        document.addEventListener('mouseup', handleMouseUp);
+      });
 
-      // Touch events
+      // Touch events - same pattern for touch devices
       track.addEventListener('touchstart', (e) => {
         if (e.target.closest('.card-fav')) return;
         StyleyeSCarousel.startDrag(state, e.touches[0].clientX);
-      }, { passive: true });
 
-      track.addEventListener('touchmove', (e) => {
-        if (state.isDragging) {
-          StyleyeSCarousel.moveDrag(state, e.touches[0].clientX, onUpdate);
-        }
-      }, { passive: true });
+        const handleTouchMove = (moveEvent) => {
+          if (state.isDragging) {
+            StyleyeSCarousel.moveDrag(state, moveEvent.touches[0].clientX, onUpdate);
+          }
+        };
 
-      track.addEventListener('touchend', () => {
-        if (state.isDragging) {
-          StyleyeSCarousel.endDrag(state, onUpdate);
-        }
-      });
+        const handleTouchEnd = () => {
+          if (state.isDragging) {
+            StyleyeSCarousel.endDrag(state, onUpdate);
+          }
+          // Clean up listeners when touch ends
+          document.removeEventListener('touchmove', handleTouchMove);
+          document.removeEventListener('touchend', handleTouchEnd);
+        };
+
+        document.addEventListener('touchmove', handleTouchMove, { passive: true });
+        document.addEventListener('touchend', handleTouchEnd);
+      }, { passive: true });
 
       // Arrow buttons
       if (prevBtn) {
@@ -1148,13 +1154,16 @@ const StyleyeSUI = {
   showToast(message, type = 'ok') {
     const { toast } = this.elements;
     if (!toast) return;
-    
+
     toast.textContent = message;
-    toast.style.borderColor = type === 'ok' ? 'var(--success)' : 'var(--warn)';
-    toast.style.color = type === 'ok' ? 'var(--success)' : 'var(--warn)';
+    // Use CSS classes instead of inline styles for maintainability
+    toast.classList.remove('success', 'warn');
+    toast.classList.add(type === 'ok' ? 'success' : 'warn');
     toast.classList.add('show');
-    
-    setTimeout(() => toast.classList.remove('show'), 2000);
+
+    setTimeout(() => {
+      toast.classList.remove('show');
+    }, 2000);
   },
   
   /**


### PR DESCRIPTION
Bug fixes:

#28 (Critical) - Memory leak in carousel event listeners
- Moved mousemove/mouseup listeners inside mousedown handler
- Listeners now attach only during active drag and remove on mouseup
- Applied same pattern for touch events to prevent accumulation

#29 (Medium) - Brittle attribute selectors in toast styling
- Replaced [style*="--success"] and [style*="--warn"] selectors
- Now uses class-based selectors .toast.success and .toast.warn
- Updated showToast() to add/remove classes instead of inline styles

#30 (Medium) - Magic numbers in physics engine
- Added config values: snapFinalizeThreshold, minAnimationVelocity, velocityFrameMultiplier, programmaticRotationFactor
- Replaced hardcoded 0.05, 0.01, 16, 0.12 with named config values
- Improves code clarity and maintainability

#31 (Medium) - StyleyeSIcons object not frozen
- Added Object.freeze(StyleyeSIcons) after nested map freezes
- Prevents accidental runtime modifications to icon system

Closes #28, #29, #30, #31