### PR TITLE
feat: enhance carousel interaction for smoother selection

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -1,6 +1,16 @@
 /**
- * StyleyeS v2.3.0 — Component Styles
+ * StyleyeS v2.4.0 — Component Styles
  * UI Components and Interactive Elements
+ *
+ * @version 2.4.0
+ * @updated 2026-01-14
+ * @changelog
+ *   - 2.4.0: Enhanced carousel card styling:
+ *            - Front card only shows selection border (orange)
+ *            - Non-front cards have transparent borders with subtle dot indicator
+ *            - Enhanced hover pop-up with CSS custom properties
+ *            - Improved focus glow responsive to hover state
+ *            - Better visual hierarchy with edge blur/dim
  */
 
 /* ============================================
@@ -950,11 +960,11 @@
 
 .carousel-track {
   position: relative;
-  height: 160px;                          /* Increased for pop-up effect + spacing */
+  height: 175px;                          /* Increased for enhanced pop-up effect */
   display: flex;
   align-items: center;
   justify-content: center;
-  perspective: 1000px;                    /* Increased for better 3D depth */
+  perspective: 1200px;                    /* Enhanced 3D depth perception */
   perspective-origin: center center;
   overflow: visible;                       /* Allow 3D overflow */
   cursor: grab;
@@ -962,7 +972,7 @@
   user-select: none;
   -webkit-user-select: none;
   margin: 0.75rem 0;
-  padding-top: 0.5rem;                     /* Space for pop-up effect */
+  padding-top: 0.75rem;                   /* Space for pop-up effect */
 }
 
 .carousel-track:active {
@@ -972,23 +982,30 @@
 /* Cards in 3D carousel - absolutely positioned */
 .carousel-track .card-item {
   position: absolute;
-  width: 140px;                            /* Keep existing width */
+  width: 140px;
   flex: none;
   will-change: transform, opacity, filter;
   backface-visibility: hidden;
   -webkit-backface-visibility: hidden;
-  transition: box-shadow 0.3s ease, border-color 0.3s ease;
+  /* Smooth transitions for visual properties only - position handled by JS */
+  transition: box-shadow 0.25s ease, border-color 0.25s ease;
+  /* CSS custom properties set by JS for dynamic effects */
+  --focus-intensity: 0;
+  --base-lift: 0px;
 }
 
-/* Non-front cards in carousel: disable hover/selection visual effects */
+/* Non-front cards in carousel: completely disable hover/selection visual effects */
 .carousel-track .card-item:not(.carousel-front) {
   cursor: default;
+  /* Hide selection border entirely on non-front cards */
+  border-color: transparent !important;
+  box-shadow: none !important;
 }
 
 .carousel-track .card-item:not(.carousel-front):hover {
-  /* No transform override - JS inline styles control positioning */
-  border-color: var(--border);
-  box-shadow: none;
+  /* No visual feedback - card is not interactive */
+  border-color: transparent !important;
+  box-shadow: none !important;
 }
 
 .carousel-track .card-item:not(.carousel-front):hover .card-content {
@@ -1009,47 +1026,115 @@
   pointer-events: none;
 }
 
-/* Non-front selected cards: muted selection indicator */
+/* Non-front selected cards: very subtle indicator only (small dot or none) */
 .carousel-track .card-item.selected:not(.carousel-front) {
-  border-color: rgba(255, 107, 53, 0.25);
-  box-shadow: none;
+  /* No border on non-front selected cards to avoid confusion */
+  border-color: transparent !important;
+  box-shadow: none !important;
 }
 
 .carousel-track .card-item.selected:not(.carousel-front) .card-content {
-  background: rgba(255, 107, 53, 0.05);
+  /* Very subtle background tint to show it's selected somewhere in carousel */
+  background: rgba(255, 107, 53, 0.03);
 }
 
 .carousel-track .card-item.selected:not(.carousel-front) .card-preview {
   box-shadow: none;
 }
 
-/* Front card in carousel: enhanced interactive styling */
+/* Subtle selection indicator dot for non-front selected cards */
+.carousel-track .card-item.selected:not(.carousel-front)::after {
+  content: '';
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  width: 6px;
+  height: 6px;
+  background: var(--c1);
+  border-radius: 50%;
+  opacity: 0.7;
+  z-index: 10;
+}
+
+/* Front card in carousel: full interactive styling with pop-up effect */
 .carousel-track .card-item.carousel-front {
   cursor: pointer;
-  transition: box-shadow 0.3s ease, border-color 0.3s ease;
+  /* Smooth transitions for hover pop-up effect */
+  transition:
+    transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.25s ease,
+    border-color 0.25s ease;
+  /* Restore default border for front card */
+  border-color: var(--border) !important;
 }
 
+/* Front card hover: enhanced pop-up effect */
 .carousel-track .card-item.carousel-front:hover {
-  border-color: rgba(255, 107, 53, 0.6);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4), 0 0 20px rgba(255, 107, 53, 0.15);
+  /* Build complete transform from CSS custom properties with hover enhancements */
+  transform:
+    translateX(var(--carousel-x, 0px))
+    translateY(calc(var(--base-lift, 0px) - 8px))
+    scale(calc(var(--carousel-scale, 1) + 0.04)) !important;
+  border-color: rgba(255, 107, 53, 0.7) !important;
+  box-shadow:
+    0 20px 45px rgba(0, 0, 0, 0.5),
+    0 0 35px rgba(255, 107, 53, 0.22),
+    0 0 0 2px rgba(255, 107, 53, 0.18);
+  /* Ensure front card is always fully visible on hover */
+  opacity: 1 !important;
+  filter: none !important;
 }
 
+.carousel-track .card-item.carousel-front:hover .card-preview {
+  height: 56px;
+}
+
+.carousel-track .card-item.carousel-front:hover .card-preview-shine {
+  opacity: 1;
+  animation: shimmerSlide 1.5s ease-in-out infinite;
+}
+
+.carousel-track .card-item.carousel-front:hover .card-content {
+  background: var(--bg-elevated);
+}
+
+/* Front card selected state: prominent selection indicator */
 .carousel-track .card-item.carousel-front.selected {
-  border-color: var(--c1);
-  box-shadow: 0 0 0 3px rgba(255, 107, 53, 0.25), 0 12px 32px rgba(0, 0, 0, 0.35);
+  border-color: var(--c1) !important;
+  box-shadow:
+    0 0 0 3px rgba(255, 107, 53, 0.3),
+    0 16px 36px rgba(0, 0, 0, 0.4),
+    inset 0 0 0 1px rgba(255, 107, 53, 0.1);
+}
+
+.carousel-track .card-item.carousel-front.selected:hover {
+  box-shadow:
+    0 0 0 3px rgba(255, 107, 53, 0.4),
+    0 20px 44px rgba(0, 0, 0, 0.5),
+    0 0 35px rgba(255, 107, 53, 0.25),
+    inset 0 0 0 1px rgba(255, 107, 53, 0.15);
 }
 
 .carousel-track .card-item.carousel-front.selected .card-content {
-  background: rgba(255, 107, 53, 0.12);
+  background: rgba(255, 107, 53, 0.14);
 }
 
 .carousel-track .card-item.carousel-front.selected .card-preview {
-  box-shadow: inset 0 0 24px rgba(255, 107, 53, 0.35);
+  box-shadow: inset 0 0 28px rgba(255, 107, 53, 0.4);
+}
+
+/* Active/pressed state for front card */
+.carousel-track .card-item.carousel-front:active {
+  transform:
+    translateX(var(--carousel-x, 0px))
+    translateY(calc(var(--base-lift, 0px) - 2px))
+    scale(calc(var(--carousel-scale, 1) - 0.02)) !important;
+  transition: transform 0.1s ease;
 }
 
 @media (min-width: 500px) {
   .carousel-track {
-    height: 180px;
+    height: 195px;
   }
   .carousel-track .card-item {
     width: 160px;
@@ -1058,30 +1143,43 @@
 
 @media (min-width: 768px) {
   .carousel-track {
-    height: 200px;
+    height: 215px;
   }
   .carousel-track .card-item {
     width: 180px;
   }
 }
 
-/* Focus glow behind center card */
+/* Focus glow behind center card - enhanced for pop-up effect */
 .carousel-track::before {
   content: '';
   position: absolute;
-  width: 200px;
-  height: 140px;
+  width: 220px;
+  height: 160px;
   background: radial-gradient(
     ellipse at center,
-    rgba(255, 107, 53, 0.18) 0%,
-    rgba(255, 107, 53, 0.08) 40%,
-    transparent 70%
+    rgba(255, 107, 53, 0.22) 0%,
+    rgba(255, 107, 53, 0.1) 35%,
+    rgba(255, 107, 53, 0.03) 60%,
+    transparent 75%
   );
   border-radius: 50%;
-  filter: blur(25px);
+  filter: blur(30px);
   pointer-events: none;
   z-index: 0;
-  transform: translateY(-12px); /* Align with lifted front card (matches frontLiftY) */
+  transform: translateY(-16px); /* Align with lifted front card (matches frontLiftY) */
+  transition: opacity 0.3s ease;
+}
+
+/* Enhance glow when front card is hovered */
+.carousel-track:has(.carousel-front:hover)::before {
+  background: radial-gradient(
+    ellipse at center,
+    rgba(255, 107, 53, 0.28) 0%,
+    rgba(255, 107, 53, 0.14) 35%,
+    rgba(255, 107, 53, 0.05) 60%,
+    transparent 75%
+  );
 }
 
 /* 3D Carousel - disable scroll-based fade indicators (not applicable) */

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -1,10 +1,16 @@
 /**
- * StyleyeS v2.3.0 — Carousel Physics Engine
+ * StyleyeS v2.4.0 — Carousel Physics Engine
  * 3D cylindrical rotation with enhanced front-card focus
  *
- * @version 2.3.0
- * @updated 2026-01-13
+ * @version 2.4.0
+ * @updated 2026-01-14
  * @changelog
+ *   - 2.4.0: Enhanced carousel interaction refinements:
+ *            - Increased radius for clearer card separation
+ *            - Smoother physics with refined friction/snap values
+ *            - Enhanced edge blur/dim effect with progressive falloff
+ *            - Pop-up effect with hover lift bonus
+ *            - Focus intensity CSS custom property for dynamic styling
  *   - 2.3.0: Memory leak fix - destroyAll() called before re-render
  *   - 2.2.0: Enhanced carousel interaction - front card pop-up, blur/dim edges,
  *            single-card selection, smoother motion
@@ -14,29 +20,33 @@ const StyleyeSCarousel = {
 
   // Configuration
   config: {
-    radius: 280,                      // Cylinder radius (px) - increased for less overlap
-    friction: 0.92,                   // Velocity decay per frame
-    snapThreshold: 0.15,              // Velocity below which snap begins
-    sensitivity: 0.35,                // Degrees per pixel dragged - slightly reduced for smoother feel
-    maxVelocity: 18,                  // Clamp throw speed
-    snapEasing: 0.12,                 // Lerp factor for snap - slightly faster snap
+    radius: 320,                      // Cylinder radius (px) - increased for less overlap and clearer separation
+    friction: 0.94,                   // Velocity decay per frame - smoother deceleration
+    snapThreshold: 0.12,              // Velocity below which snap begins - earlier snap for precision
+    sensitivity: 0.32,                // Degrees per pixel dragged - refined for smooth feel
+    maxVelocity: 16,                  // Clamp throw speed - slightly lower for controlled motion
+    snapEasing: 0.14,                 // Lerp factor for snap - slightly faster snap
 
     // Physics thresholds
-    snapFinalizeThreshold: 0.05,      // Delta below which snap finalizes
-    minAnimationVelocity: 0.01,       // Velocity below which animation stops
+    snapFinalizeThreshold: 0.03,      // Delta below which snap finalizes - tighter precision
+    minAnimationVelocity: 0.008,      // Velocity below which animation stops
     velocityFrameMultiplier: 16,      // Normalizes velocity to ~60fps (1000ms/60fps ≈ 16ms)
-    programmaticRotationFactor: 0.12, // Velocity factor for rotateTo()
+    programmaticRotationFactor: 0.14, // Velocity factor for rotateTo()
 
-    // Depth visual treatment
-    minScale: 0.55,                   // Scale at back - smaller for more depth
+    // Depth visual treatment - enhanced for better hierarchy
+    minScale: 0.5,                    // Scale at back - smaller for stronger depth effect
     maxScale: 1.0,                    // Scale at front
-    minOpacity: 0.25,                 // Opacity at back - more faded
-    maxBlur: 6,                       // Blur (px) at back - stronger blur
-    zThreshold: 0.7,                  // Z threshold for front card (only front card is interactive)
+    minOpacity: 0.18,                 // Opacity at back - more faded for focus on center
+    maxBlur: 8,                       // Blur (px) at back - stronger blur for edge cards
+    zThreshold: 0.85,                 // Z threshold for front card - tighter zone for single card focus
 
     // Pop-up effect for front card
-    frontLiftY: -12,                  // Pixels to lift front card (negative = up)
-    frontThreshold: 0.85             // Z value above which card gets full lift
+    frontLiftY: -16,                  // Pixels to lift front card (negative = up) - more prominent
+    frontThreshold: 0.88,             // Z value above which card gets full lift - tighter threshold
+
+    // Hover enhancement for front card
+    hoverLiftBonus: -6,               // Additional lift on hover (negative = up)
+    hoverScaleBonus: 0.04             // Additional scale on hover
   },
 
   // Per-carousel state (keyed by category)
@@ -98,10 +108,24 @@ const StyleyeSCarousel = {
     // Normalize z from [-1, +1] to [0, 1]
     const zNorm = (z + 1) / 2;
 
-    // Interpolate visual properties
+    // Calculate edge factor for progressive blur/dim at carousel edges
+    // 0 = center, 1 = far edge (based on X position)
+    const normalizedX = Math.abs(x) / radius;
+    const edgeFactor = Math.pow(normalizedX, 1.5); // Non-linear for stronger edge effect
+
+    // Enhanced opacity calculation - stronger falloff for non-center cards
+    // Combine depth-based and edge-based opacity
+    const depthOpacity = minOpacity + (1 - minOpacity) * zNorm;
+    const edgeOpacityPenalty = edgeFactor * 0.35; // Up to 35% additional fade at edges
+    const opacity = Math.max(minOpacity, depthOpacity - edgeOpacityPenalty);
+
+    // Enhanced blur - combine depth blur with edge blur
+    const depthBlur = maxBlur * (1 - zNorm);
+    const edgeBlur = edgeFactor * 3; // Additional 3px blur at edges
+    const blur = depthBlur + edgeBlur;
+
+    // Scale with depth
     const scale = minScale + (maxScale - minScale) * zNorm;
-    const opacity = minOpacity + (1 - minOpacity) * zNorm;
-    const blur = maxBlur * (1 - zNorm);
     const zIndex = Math.round(zNorm * 100);
 
     // Calculate Y lift for front card pop-up effect
@@ -118,13 +142,21 @@ const StyleyeSCarousel = {
     // Determine if this is the "front" card (for special styling)
     const isFront = z > zThreshold;
 
+    // Calculate focus intensity (0-1) for front card - used for CSS custom property
+    const focusIntensity = isFront ? Math.min(1, (z - zThreshold) / (1 - zThreshold)) : 0;
+
     return {
       transform: `translateX(${x.toFixed(1)}px) translateY(${liftY.toFixed(1)}px) scale(${scale.toFixed(3)})`,
       opacity: opacity.toFixed(3),
       filter: blur > 0.1 ? `blur(${blur.toFixed(1)}px)` : 'none',
       zIndex,
       pointerEvents: isFront ? 'auto' : 'none',
-      isFront
+      isFront,
+      focusIntensity,
+      liftY,
+      // Raw values for CSS custom properties
+      x,
+      scale
     };
   },
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -932,11 +932,27 @@ const StyleyeSUI = {
       const currentAngle = state.rotation + itemAngle;
       const styles = StyleyeSCarousel.getStyleForAngle(currentAngle);
 
-      card.style.transform = styles.transform;
+      // For non-front cards, apply full inline styles
+      // For front card, use CSS custom properties so CSS can add hover effects
+      if (!styles.isFront) {
+        card.style.transform = styles.transform;
+      } else {
+        // Set base values as CSS custom properties for front card
+        // This allows CSS :hover to build on these values
+        card.style.setProperty('--carousel-x', `${styles.x.toFixed(1)}px`);
+        card.style.setProperty('--carousel-scale', styles.scale.toFixed(3));
+        // Set base transform for when not hovering
+        card.style.transform = styles.transform;
+      }
+
       card.style.opacity = styles.opacity;
       card.style.filter = styles.filter;
       card.style.zIndex = styles.zIndex;
       card.style.pointerEvents = styles.pointerEvents;
+
+      // Set focus intensity as CSS custom property for hover/selection effects
+      card.style.setProperty('--focus-intensity', styles.focusIntensity.toFixed(3));
+      card.style.setProperty('--base-lift', `${styles.liftY.toFixed(1)}px`);
 
       // Toggle carousel-front class based on position
       card.classList.toggle('carousel-front', styles.isFront);


### PR DESCRIPTION
- Increase carousel radius (280→320px) for clearer card separation
- Improve physics: smoother friction (0.92→0.94), refined snap threshold
- Add progressive edge blur/dim effect for better visual hierarchy
- Restrict selection border to front card only (non-front cards transparent)
- Add subtle dot indicator for non-front selected cards
- Enhanced pop-up effect on hover with CSS custom properties
- Add focus glow enhancement responsive to hover state
- Version bump to 2.4.0

The active front card now rises up more prominently and only the
centered card shows interactive selection styling, preventing
accidental clicks on adjacent cards.