### PR TITLE
feat: replace emojis with vector icons for categories

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -819,6 +819,22 @@
   transition: all 0.2s ease;
   white-space: nowrap;
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.cat-icon {
+  width: 1rem;
+  height: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cat-icon svg {
+  width: 100%;
+  height: 100%;
 }
 
 .cat-btn:hover {
@@ -869,8 +885,18 @@
   gap: 0.5rem;
 }
 
-.category-title .emoji {
-  font-size: 1rem;
+.category-title .category-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--c1);
+}
+
+.category-title .category-icon svg {
+  width: 100%;
+  height: 100%;
 }
 
 .carousel-nav {
@@ -1655,7 +1681,24 @@
 }
 
 .row-icon {
-  font-size: 1rem;
+  width: 1.25rem;
+  height: 1.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.row-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.type-control .row-icon {
+  color: var(--c1);
+}
+
+.type-style .row-icon {
+  color: var(--c2);
 }
 
 .row-name {

--- a/icons/categories/all-controls.svg
+++ b/icons/categories/all-controls.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="8" height="8" rx="2"/>
+  <rect x="13" y="3" width="8" height="8" rx="2"/>
+  <rect x="3" y="13" width="8" height="8" rx="2"/>
+  <rect x="13" y="13" width="8" height="8" rx="2"/>
+  <circle cx="7" cy="7" r="1.5"/>
+  <circle cx="17" cy="7" r="1.5"/>
+  <circle cx="7" cy="17" r="1.5"/>
+  <circle cx="17" cy="17" r="1.5"/>
+</svg>

--- a/icons/categories/all-styles.svg
+++ b/icons/categories/all-styles.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 3l1.5 3.5L17 8l-3.5 1.5L12 13l-1.5-3.5L7 8l3.5-1.5L12 3z"/>
+  <path d="M5 16l1 2 2 1-2 1-1 2-1-2-2-1 2-1 1-2z"/>
+  <path d="M18 14l.75 1.5 1.5.75-1.5.75-.75 1.5-.75-1.5-1.5-.75 1.5-.75.75-1.5z"/>
+</svg>

--- a/icons/categories/anti-cast.svg
+++ b/icons/categories/anti-cast.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 3l1.5 3 3.5.5-2.5 2.5.5 3.5-3-1.5-3 1.5.5-3.5L7 6.5l3.5-.5L12 3z"/>
+  <path d="M4.5 16.5l.75 1.5 1.5.75-1.5.75-.75 1.5-.75-1.5-1.5-.75 1.5-.75.75-1.5z"/>
+  <path d="M19 14l.6 1.2 1.2.6-1.2.6-.6 1.2-.6-1.2-1.2-.6 1.2-.6.6-1.2z"/>
+</svg>

--- a/icons/categories/art.svg
+++ b/icons/categories/art.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2"/>
+  <path d="M3 9h18"/>
+  <path d="M9 21V9"/>
+  <circle cx="6" cy="6" r="1" fill="currentColor"/>
+</svg>

--- a/icons/categories/cinematic.svg
+++ b/icons/categories/cinematic.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="2" y="4" width="20" height="16" rx="2"/>
+  <path d="M2 8h20"/>
+  <path d="M6 4v4"/>
+  <path d="M10 4v4"/>
+  <path d="M14 4v4"/>
+  <path d="M18 4v4"/>
+  <polygon points="10 14 10 18 15 16 10 14"/>
+</svg>

--- a/icons/categories/color.svg
+++ b/icons/categories/color.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="13.5" cy="6.5" r="2.5"/>
+  <circle cx="17.5" cy="10.5" r="2.5"/>
+  <circle cx="8.5" cy="7.5" r="2.5"/>
+  <circle cx="6.5" cy="12.5" r="2.5"/>
+  <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12c0 1.821.487 3.53 1.338 5L6 21l5-2.662A9.956 9.956 0 0012 22z"/>
+</svg>

--- a/icons/categories/control.svg
+++ b/icons/categories/control.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 18h6"/>
+  <path d="M10 22h4"/>
+  <path d="M15.09 14c.18-.98.65-1.74 1.41-2.5A4.65 4.65 0 0018 8 6 6 0 006 8c0 1 .23 2.23 1.5 3.5A4.61 4.61 0 018.91 14"/>
+</svg>

--- a/icons/categories/digital.svg
+++ b/icons/categories/digital.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="2" y="3" width="20" height="14" rx="2"/>
+  <path d="M8 21h8"/>
+  <path d="M12 17v4"/>
+  <path d="M6 8h.01"/>
+  <path d="M10 8h.01"/>
+</svg>

--- a/icons/categories/era.svg
+++ b/icons/categories/era.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 22h14"/>
+  <path d="M5 2h14"/>
+  <path d="M17 22v-4.172a2 2 0 00-.586-1.414L12 12l-4.414 4.414A2 2 0 007 17.828V22"/>
+  <path d="M7 2v4.172a2 2 0 00.586 1.414L12 12l4.414-4.414A2 2 0 0017 6.172V2"/>
+</svg>

--- a/icons/categories/lighting.svg
+++ b/icons/categories/lighting.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 18h6"/>
+  <path d="M10 22h4"/>
+  <path d="M15.09 14c.18-.98.65-1.74 1.41-2.5A4.65 4.65 0 0018 8 6 6 0 006 8c0 1 .23 2.23 1.5 3.5A4.61 4.61 0 018.91 14"/>
+  <line x1="12" y1="2" x2="12" y2="3"/>
+  <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+  <line x1="2" y1="12" x2="3" y2="12"/>
+  <line x1="21" y1="12" x2="22" y2="12"/>
+  <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+</svg>

--- a/icons/categories/mood.svg
+++ b/icons/categories/mood.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
+</svg>

--- a/icons/categories/photo.svg
+++ b/icons/categories/photo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M23 19a2 2 0 01-2 2H3a2 2 0 01-2-2V8a2 2 0 012-2h4l2-3h6l2 3h4a2 2 0 012 2z"/>
+  <circle cx="12" cy="13" r="4"/>
+</svg>

--- a/icons/categories/style.svg
+++ b/icons/categories/style.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="13.5" cy="6.5" r="2.5"/>
+  <circle cx="17.5" cy="10.5" r="2.5"/>
+  <circle cx="8.5" cy="7.5" r="2.5"/>
+  <circle cx="6.5" cy="12.5" r="2.5"/>
+  <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12c0 1.821.487 3.53 1.338 5L6 21l5-2.662A9.956 9.956 0 0012 22z"/>
+</svg>

--- a/icons/categories/texture.svg
+++ b/icons/categories/texture.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="7" height="7" rx="1"/>
+  <rect x="14" y="3" width="7" height="7" rx="1"/>
+  <rect x="3" y="14" width="7" height="7" rx="1"/>
+  <rect x="14" y="14" width="7" height="7" rx="1"/>
+</svg>

--- a/icons/categories/white-balance.svg
+++ b/icons/categories/white-balance.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <path d="M12 2v20"/>
+  <path d="M12 2a10 10 0 010 20" fill="currentColor" fill-opacity="0.3"/>
+</svg>

--- a/js/config.js
+++ b/js/config.js
@@ -37,6 +37,7 @@ const StyleyeSConfig = {
 
   // Icon Configuration
   ICON_BASE_PATH: 'icons/models/',
+  CATEGORY_ICON_PATH: 'icons/categories/',
 
   // Aspect Ratios
   aspectRatios: [
@@ -220,22 +221,30 @@ const StyleyeSConfig = {
     }
   },
 
-  // Category Emojis
-  categoryEmojis: {
-    'Photo': '📷',
-    'Cinematic': '🎬',
-    'Art': '🖼️',
-    'Digital': '💻',
-    'Mood': '🌙',
-    'Texture': '🧱',
-    'Color': '🎨',
-    'Era': '⏳'
+  // Category Icons (SVG paths)
+  categoryIcons: {
+    'all': 'all-styles.svg',
+    'Photo': 'photo.svg',
+    'Cinematic': 'cinematic.svg',
+    'Art': 'art.svg',
+    'Digital': 'digital.svg',
+    'Mood': 'mood.svg',
+    'Texture': 'texture.svg',
+    'Color': 'color.svg',
+    'Era': 'era.svg'
   },
 
-  controlCategoryEmojis: {
-    'Lighting': '💡',
-    'White Balance': '⚪️',
-    'Anti-Cast': '🧼'
+  controlCategoryIcons: {
+    'all': 'all-controls.svg',
+    'Lighting': 'lighting.svg',
+    'White Balance': 'white-balance.svg',
+    'Anti-Cast': 'anti-cast.svg'
+  },
+
+  // Stack row icons
+  stackIcons: {
+    'style': 'style.svg',
+    'control': 'control.svg'
   }
 };
 
@@ -250,5 +259,6 @@ StyleyeSConfig.models.forEach(model => {
 });
 Object.freeze(StyleyeSConfig.models);
 Object.freeze(StyleyeSConfig.modelConfig);
-Object.freeze(StyleyeSConfig.categoryEmojis);
-Object.freeze(StyleyeSConfig.controlCategoryEmojis);
+Object.freeze(StyleyeSConfig.categoryIcons);
+Object.freeze(StyleyeSConfig.controlCategoryIcons);
+Object.freeze(StyleyeSConfig.stackIcons);

--- a/js/ui.js
+++ b/js/ui.js
@@ -56,14 +56,36 @@ const StyleyeSUI = {
   },
 
   /**
-   * Preload all model icons for better performance
+   * Preload all model and category icons for better performance
    * @returns {Promise<void>}
    */
   async preloadIcons() {
-    const iconPromises = StyleyeSConfig.models.map(model =>
+    // Preload model icons
+    const modelIconPromises = StyleyeSConfig.models.map(model =>
       this.loadIcon(model.iconPath)
     );
-    await Promise.all(iconPromises);
+
+    // Preload category icons
+    const categoryIconPromises = Object.values(StyleyeSConfig.categoryIcons).map(iconPath =>
+      this.loadCategoryIcon(iconPath)
+    );
+
+    // Preload control category icons
+    const controlIconPromises = Object.values(StyleyeSConfig.controlCategoryIcons).map(iconPath =>
+      this.loadCategoryIcon(iconPath)
+    );
+
+    // Preload stack icons
+    const stackIconPromises = Object.values(StyleyeSConfig.stackIcons).map(iconPath =>
+      this.loadCategoryIcon(iconPath)
+    );
+
+    await Promise.all([
+      ...modelIconPromises,
+      ...categoryIconPromises,
+      ...controlIconPromises,
+      ...stackIconPromises
+    ]);
   },
 
   /**
@@ -74,6 +96,48 @@ const StyleyeSUI = {
   getIconSync(iconPath) {
     if (!iconPath) return '';
     const fullPath = StyleyeSConfig.ICON_BASE_PATH + iconPath;
+    return this.iconCache[fullPath] || '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" fill="currentColor" opacity="0.3"/></svg>';
+  },
+
+  /**
+   * Load external category SVG icon content
+   * @param {string} iconPath - Relative path to icon file
+   * @returns {Promise<string>} SVG content
+   */
+  async loadCategoryIcon(iconPath) {
+    if (!iconPath) return '';
+
+    const fullPath = StyleyeSConfig.CATEGORY_ICON_PATH + iconPath;
+
+    // Return cached icon if available
+    if (this.iconCache[fullPath]) {
+      return this.iconCache[fullPath];
+    }
+
+    try {
+      const response = await fetch(fullPath);
+      if (!response.ok) {
+        console.warn(`Failed to load category icon: ${fullPath}`);
+        return '';
+      }
+      const svgContent = await response.text();
+      // Cache the loaded icon
+      this.iconCache[fullPath] = svgContent;
+      return svgContent;
+    } catch (error) {
+      console.warn(`Error loading category icon ${fullPath}:`, error);
+      return '';
+    }
+  },
+
+  /**
+   * Get cached category icon or placeholder
+   * @param {string} iconPath - Relative path to icon file
+   * @returns {string} SVG content or placeholder
+   */
+  getCategoryIconSync(iconPath) {
+    if (!iconPath) return '';
+    const fullPath = StyleyeSConfig.CATEGORY_ICON_PATH + iconPath;
     return this.iconCache[fullPath] || '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" fill="currentColor" opacity="0.3"/></svg>';
   },
   
@@ -562,25 +626,24 @@ const StyleyeSUI = {
   renderCategories() {
     const { categories } = this.elements;
     if (!categories) return;
-    
-    let cats, activeCat, emojiMap;
-    
+
+    let cats, activeCat, iconMap;
+
     if (StyleyeSState.pickerMode === 'styles') {
       cats = ['all', ...StyleyeSData.getStyleCategories()];
       activeCat = StyleyeSState.activeCategory;
-      emojiMap = StyleyeSConfig.categoryEmojis;
+      iconMap = StyleyeSConfig.categoryIcons;
     } else {
       cats = ['all', ...StyleyeSData.getControlCategories()];
       activeCat = StyleyeSState.controlActiveCategory;
-      emojiMap = StyleyeSConfig.controlCategoryEmojis;
+      iconMap = StyleyeSConfig.controlCategoryIcons;
     }
-    
+
     categories.innerHTML = cats.map(cat => {
-      const emoji = cat === 'all' 
-        ? (StyleyeSState.pickerMode === 'styles' ? '✨' : '🧩') 
-        : emojiMap[cat] || '';
+      const iconPath = iconMap[cat] || iconMap['all'];
+      const iconContent = this.getCategoryIconSync(iconPath);
       const label = cat === 'all' ? 'All' : cat;
-      return `<button class="cat-btn ${cat === activeCat ? 'active' : ''}" data-cat="${cat}">${emoji} ${label}</button>`;
+      return `<button class="cat-btn ${cat === activeCat ? 'active' : ''}" data-cat="${cat}"><span class="cat-icon">${iconContent}</span> ${label}</button>`;
     }).join('');
   },
   
@@ -672,7 +735,7 @@ const StyleyeSUI = {
     if (!stylesContainer) return;
 
     const activeCat = StyleyeSState.activeCategory;
-    const emojiMap = StyleyeSConfig.categoryEmojis;
+    const iconMap = StyleyeSConfig.categoryIcons;
 
     let categories;
     if (activeCat === 'all') {
@@ -699,13 +762,14 @@ const StyleyeSUI = {
 
       if (styles.length === 0) return '';
 
-      const emoji = emojiMap[category] || '✨';
+      const iconPath = iconMap[category] || iconMap['all'];
+      const iconContent = this.getCategoryIconSync(iconPath);
       const sanitizedCat = this.sanitizeAttr(category);
 
       return `
         <section class="style-category-section" data-category="${sanitizedCat}">
           <div class="category-header">
-            <h3 class="category-title"><span class="emoji">${emoji}</span> ${this.escapeHtml(category)}</h3>
+            <h3 class="category-title"><span class="category-icon">${iconContent}</span> ${this.escapeHtml(category)}</h3>
             <div class="carousel-nav">
               <button class="carousel-arrow prev" data-carousel-prev="${sanitizedCat}" aria-label="Previous" type="button">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -866,17 +930,20 @@ const StyleyeSUI = {
   renderStack() {
     const { stackList, totalCount } = this.elements;
     if (!stackList || !totalCount) return;
-    
+
     const total = StyleyeSState.getTotalCount();
     totalCount.textContent = `${total} / 8`;
-    
+
     if (total === 0) {
       stackList.innerHTML = '<span class="stack-empty">Tap styles or lighting to build your recipe</span>';
       return;
     }
-    
+
+    const controlIcon = this.getCategoryIconSync(StyleyeSConfig.stackIcons.control);
+    const styleIcon = this.getCategoryIconSync(StyleyeSConfig.stackIcons.style);
+
     let html = '';
-    
+
     // Render controls first
     StyleyeSState.controlStack.forEach(id => {
       const item = StyleyeSData.getControlById(id);
@@ -884,7 +951,7 @@ const StyleyeSUI = {
         html += `
           <div class="stack-row type-control">
             <div class="row-info">
-              <span class="row-icon">💡</span>
+              <span class="row-icon">${controlIcon}</span>
               <span class="row-name">${item.name}</span>
             </div>
             <button class="row-remove" data-remove-ctrl="${id}" aria-label="Remove ${item.name}">×</button>
@@ -892,7 +959,7 @@ const StyleyeSUI = {
         `;
       }
     });
-    
+
     // Render styles
     StyleyeSState.stack.forEach(id => {
       const item = StyleyeSData.getStyleById(id);
@@ -900,7 +967,7 @@ const StyleyeSUI = {
         html += `
           <div class="stack-row type-style">
             <div class="row-info">
-              <span class="row-icon">🎨</span>
+              <span class="row-icon">${styleIcon}</span>
               <span class="row-name">${item.name}</span>
             </div>
             <button class="row-remove" data-remove-style="${id}" aria-label="Remove ${item.name}">×</button>
@@ -908,7 +975,7 @@ const StyleyeSUI = {
         `;
       }
     });
-    
+
     stackList.innerHTML = html;
   },
   


### PR DESCRIPTION
- Add SVG icons for style categories (Photo, Cinematic, Art, Digital, Mood, Texture, Color, Era)
- Add SVG icons for control categories (Lighting, White Balance, Anti-Cast)
- Add SVG icons for stack row indicators (style, control)
- Update config to use icon paths instead of emoji strings
- Update UI to load and render SVG icons with caching
- Add CSS styles for icon sizing and coloring