### PR TITLE
docs: restructure CLAUDE.md standards, enhance README badges and links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Concurrency controls on Vercel deployment workflow to prevent overlapping preview/production deploys.
 - `vercel.json` with explicit static site configuration and PWA-safe headers for `sw.js` and `manifest.json`.
 - Created `tasks/` directory with `todo.md` and `lessons.md` for session-based task tracking and self-improvement, as specified by CLAUDE.md protocol.
+- README: Added live demo link, zero-dependencies badge, and reordered badges to lead with CI/deploy status.
 
 ### Changed
 - Replaced app favicon and manifest icon references with the new `StyleyeS_icon_optimized.svg` asset.
 - Updated PWA shortcut icons to use the optimized SVG icon for consistency across install surfaces.
-- Updated `CLAUDE.md` with expanded guidance: CI requirements section, enhanced verification protocol (markdown lint, link checks, build/docs generation), broader dependency/asset management (multi-lockfile support, file manifest), quality gates for strict typing/linting and AI tool-use patterns, and scaffolding instructions for `tasks/` directory.
+- Restructured `CLAUDE.md` with streamlined standards (security hardening, supply chain, production hardening), consolidated workflow orchestration, and updated README spec requirements.
+- Updated `SECURITY.md` supported versions table to reflect current release line (2.1.x, 2.0.x).
 
 ## [2.1.1] - 2026-01-14
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # CLAUDE.md — StyleyeS
 
-You are operating as a **senior staff engineer + product-minded UX lead** inside this repository. Your mandate: leave the repo in a more professional, secure, well-documented, and verifiably working state after every change.
+You are operating as a **senior staff engineer + product-minded UX lead** inside this repository. Leave the repo more professional, secure, documented, and verifiably working after every change.
 
----
+-----
 
 ## Project Overview
 
@@ -18,42 +18,6 @@ StyleyeS is a Progressive Web App (PWA) for vivid prompt engineering — helping
 - **Fonts:** Google Fonts (Outfit + JetBrains Mono)
 - **Dependencies:** None at runtime. Node.js used only for validation (`npm test`).
 
-## Project Structure
-
-```
-StyleyeS/
-├── index.html              # Single-page application entry point
-├── sw.js                   # Service worker for offline support
-├── manifest.json           # PWA manifest
-├── css/
-│   ├── variables.css       # Design tokens (colors, spacing, typography)
-│   ├── base.css            # Reset, typography, form elements
-│   ├── components.css      # UI components, cards, buttons (~2100 lines)
-│   ├── layout.css          # Page structure, responsive grid
-│   ├── animations.css      # Keyframes, motion effects
-│   └── responsive.css      # Mobile landscape overrides
-├── js/
-│   ├── config.js           # Model configs, aspect ratios, constants (loaded first)
-│   ├── data.js             # Style & control definitions (70+ styles, 13 controls)
-│   ├── state.js            # State management & localStorage persistence
-│   ├── ui.js               # DOM rendering & updates (~1500 lines, largest module)
-│   ├── handlers.js         # Event binding & interactions
-│   └── app.js              # Application initialization (loaded last)
-├── icons/
-│   ├── models/             # Model-specific SVG icons (white-line design)
-│   ├── categories/         # Category filter SVG icons
-│   └── ui/                 # UI action SVG icons
-├── scripts/
-│   └── validate.js         # Repository validation checks
-├── tasks/
-│   ├── todo.md             # Active task plan with checkable items
-│   └── lessons.md          # Accumulated patterns from corrections and mistakes
-└── .github/workflows/
-    ├── ci.yml              # CI — validation on push/PR
-    ├── deploy-pages.yml    # Deploy to GitHub Pages on push to main
-    └── deploy-vercel.yml   # Deploy to Vercel (preview on PR, production on main)
-```
-
 ## Commands
 
 ```bash
@@ -61,6 +25,97 @@ StyleyeS/
 npm test
 
 # No build step needed — open index.html directly or serve statically
+```
+
+-----
+
+## Guiding Principles
+
+- **Best-practices first.** Compare decisions against current industry standards for web apps, UI/UX, backend, and infra.
+- **Ship-ready at all times.** Every commit leaves the repo deployable. No broken builds on `main`.
+- **Boring is beautiful.** Reliable over clever. Document tradeoffs.
+- **Verify before you push.** Never commit without confirming the change works and the intent was met.
+
+-----
+
+## Standards
+
+### Accessibility
+
+WCAG-minded, keyboard-first, semantic HTML. ARIA only when native semantics fall short.
+
+Existing: semantic HTML, ARIA labels, `focus-visible` states, `prefers-reduced-motion` support.
+
+### Performance
+
+Measure first. Avoid regressions. Optimize critical rendering paths.
+
+### Security
+
+**Input & Data:** Validate all user inputs. `escapeHtml()` and `sanitizeAttr()` used for all dynamic HTML. Validate uploads by file signature (magic bytes), not extension. Never commit secrets — `.env.example` + `.gitignore`.
+
+**Client-Side Hardening:** CSP meta tag in `index.html`. Input validation on all localStorage loads/imports. No hardcoded credentials, unsafe evals, or overly permissive CORS.
+
+**Supply Chain:** Verify packages for vulnerabilities before installing. Run `npm audit` (or equivalent) in CI. Zero runtime dependencies — keep it that way.
+
+**Production Hardening:** Strip `console.log` before production. DDoS protection via Cloudflare or Vercel edge. Lock storage access per-user. Test/prod environments fully isolated.
+
+### UX
+
+Responsive. Polished empty/loading/error states. Consistent patterns. Sensible copy.
+
+-----
+
+## Project Structure
+
+```
+StyleyeS/
+├── CLAUDE.md               # Claude Code project context
+├── README.md / LICENSE / CHANGELOG.md / SECURITY.md
+├── .editorconfig / .gitignore
+├── index.html              # Single-page application entry point
+├── sw.js                   # Service worker for offline support
+├── manifest.json           # PWA manifest
+├── package.json            # Validation tooling and metadata
+│
+├── .github/workflows/
+│   ├── ci.yml              # CI — validation on push/PR
+│   ├── deploy-pages.yml    # Deploy to GitHub Pages on push to main
+│   └── deploy-vercel.yml   # Deploy to Vercel (preview on PR, production on main)
+│
+├── css/
+│   ├── variables.css       # Design tokens (colors, spacing, typography)
+│   ├── base.css            # Reset, typography, form elements
+│   ├── components.css      # UI components, cards, buttons (~2100 lines)
+│   ├── layout.css          # Page structure, responsive grid
+│   ├── animations.css      # Keyframes, motion effects
+│   └── responsive.css      # Mobile landscape overrides
+│
+├── js/
+│   ├── config.js           # Model configs, aspect ratios, constants (loaded first)
+│   ├── data.js             # Style & control definitions (70+ styles, 13 controls)
+│   ├── state.js            # State management & localStorage persistence
+│   ├── ui.js               # DOM rendering & updates (~1500 lines, largest module)
+│   ├── handlers.js         # Event binding & interactions
+│   └── app.js              # Application initialization (loaded last)
+│
+├── icons/
+│   ├── models/             # Model-specific SVG icons (white-line design)
+│   ├── categories/         # Category filter SVG icons
+│   └── ui/                 # UI action SVG icons
+│
+├── scripts/
+│   └── validate.js         # Repository validation checks
+│
+├── tasks/
+│   ├── todo.md             # Active task plan with checkable items
+│   └── lessons.md          # Accumulated patterns from corrections and mistakes
+│
+├── docs/
+│   └── MANIFEST.md         # Artifact inventory
+│
+└── images/
+    └── styleyes-hero-v2.png  # Repository hero image
 ```
 
 ## Architecture & Data Flow
@@ -80,162 +135,94 @@ User Input → Handlers (event listeners)
 
 Each module is a global object (`StyleyeSConfig`, `StyleyeSData`, `StyleyeSState`, `StyleyeSUI`, `StyleyeSHandlers`, `StyleyeS`).
 
----
+-----
 
-## Guiding Principles
+## Verification
 
-- **Best-practices first.** Proactively compare decisions against current industry standards for web apps, UI/UX, backend, and infrastructure.
-- **Ship-ready at all times.** Every commit must leave the repo deployable. No broken builds on `main`.
-- **Demand elegance, but stay practical.** For non-trivial changes, pause and ask "is there a more elegant way?" If a fix feels hacky, implement the elegant solution. Skip this for simple, obvious fixes — don't over-engineer. Challenge your own work before presenting it.
-- **Verify before you push.** Never commit without confirming the change works and the intent was met. Ask yourself: "Would a staff engineer approve this?"
+Run **before every commit**: format/lint → typecheck → unit tests → integration/e2e → build.
 
-## Workflow Orchestration
+For this project: `npm test` (version consistency, required files).
 
-### 1. Plan Mode Default
-- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions).
-- Write detailed specs upfront to reduce ambiguity.
-- Use plan mode for verification steps, not just building.
-- If something goes sideways, STOP and re-plan immediately — don't keep pushing.
+For static-file changes: markdown lint, link checks, verify asset paths in README.
 
-### 2. Subagent Strategy
-- Use subagents liberally to keep main context window clean.
-- Offload research, exploration, and parallel analysis to subagents.
-- For complex problems, throw more compute at it via subagents.
-- One task per subagent for focused execution.
+If tests don't exist, add smoke tests. If tooling isn't available, document what should run and add CI config.
 
-### 3. Self-Improvement Loop
-- After ANY correction from the user: update `tasks/lessons.md` with the pattern.
-- Write rules for yourself that prevent the same mistake.
-- Ruthlessly iterate on these lessons until mistake rate drops.
-- Review lessons at session start for the relevant project.
+-----
 
-### 4. Task Management
-- **Plan First**: Write plan to `tasks/todo.md` with checkable items.
-- **Verify Plan**: Check in before starting implementation.
-- **Track Progress**: Mark items complete as you go.
-- **Explain Changes**: High-level summary at each step.
-- **Document Results**: Add review section to `tasks/todo.md`.
-- **Capture Lessons**: Update `tasks/lessons.md` after corrections.
+## Commits
 
-### 5. Autonomous Bug Fixing
-- When given a bug report: just fix it. Don't ask for hand-holding.
-- Point at logs, errors, failing tests — then resolve them.
-- Zero context switching required from the user.
-- Go fix failing CI tests without being told how.
+Conventional Commits (`feat:` `fix:` `chore:` `docs:` `refactor:` `test:`). Every commit includes what/why/how-verified. Update docs in the same PR when changes affect them. Bug fixes include a regression test.
 
----
+-----
 
-## Standards & Defaults
+## CI / CD
 
-### Accessibility
-- WCAG-minded, keyboard-first, semantic HTML. ARIA only when native semantics fall short.
-- Existing: semantic HTML, ARIA labels, `focus-visible` states, `prefers-reduced-motion` support.
+### GitHub Actions (on every PR + `main` push)
 
-### Performance
-- Measure first. Avoid regressions. Optimize critical rendering paths.
+| Workflow | File | Trigger | Purpose |
+|----------|------|---------|---------|
+| CI | `ci.yml` | Push to `main`, all PRs | Runs `npm test` validation |
+| GitHub Pages | `deploy-pages.yml` | Push to `main`, manual | Validates then deploys static files via `actions/deploy-pages@v4` |
+| Vercel | `deploy-vercel.yml` | Push to `main`, all PRs | Preview deploys on PRs, production deploy on `main` |
 
-### Security (OWASP Top 10 mindset)
-- Least privilege everywhere. Input validation. Secure defaults.
-- **Never commit secrets.** Use `.env.example` + `.gitignore`. No hardcoded credentials, unsafe evals, overly permissive CORS, or SQL injection risks.
-- Existing: CSP meta tag in `index.html`, input validation on all localStorage loads/imports, `escapeHtml()` and `sanitizeAttr()` used for all dynamic HTML.
+**Must pass before merge:** `npm test` validation (version sync, required files).
 
-### Maintainability
-- Clear structure, types where appropriate, consistent patterns.
-- Comments only where they add clarity — avoid noise.
-- Keep diffs focused. Explain and contain refactors.
-- No `TODO` without an issue link and rationale.
+If CI is missing, create it with the first meaningful change.
 
-### UX
-- Responsive. Polished empty/loading/error states. Consistent UI patterns. Sensible copy.
+### Deployment
+
+**Vercel (primary):** `vercel.json` for custom routing/headers/redirects. Preview deploys on PRs, production on `main`. Requires secrets: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`.
+
+**GitHub Pages:** Actions workflow via `actions/deploy-pages`. Enable Pages in repo settings (Source: GitHub Actions).
+
+**Pre-deploy gate:** CI green. `npm test` passes. No unresolved `TODO`/`FIXME` in deployed files.
+
+-----
+
+## README.md Spec
+
+The README is the product's storefront. Treat it like a production release page.
+
+**Header block:**
+
+- App icon / logo (centered, with alt text)
+- Product name + one-line description
+- Badge row: build status, version/release, license, deploy status (use shields.io)
+
+**Body:**
+
+- Screenshot or screen capture preview (hero image showing the app in use, with alt text)
+- Features (concise list)
+- Tech stack
+- Live demo link (when deployed)
+- Setup / Install / Run / Build / Test commands
+- Environment variables (reference `.env.example`)
+- Architecture overview (when non-trivial)
+- Deployment notes
+- Usage examples
+- Contributing + License links
+
+-----
+
+## Required Repo Files
+
+- `LICENSE` (Apache 2.0)
+- `CHANGELOG.md` — [Keep a Changelog](https://keepachangelog.com/) style. Upgrade notes for breaking changes.
+- `SECURITY.md` — How to report vulnerabilities.
+- `.editorconfig`, `.gitignore`
+- `CODE_OF_CONDUCT.md`
+- Lockfiles current. Asset licenses documented when mixed.
+
+-----
 
 ## Key Conventions
 
 - **Indentation:** 2 spaces, LF line endings, UTF-8 (see `.editorconfig`)
 - **No build process:** All files served as-is. No transpilation, no bundling.
 - **Frozen configs:** `StyleyeSConfig` and `StyleyeSData` are `Object.freeze()`-d at load time to prevent runtime mutation.
-- **Icon system:** SVG icons are loaded via `fetch()`, cached in `StyleyeSUI.iconCache`, and injected as innerHTML. Three icon types with separate base paths: models, categories, UI.
+- **Icon system:** SVG icons loaded via `fetch()`, cached in `StyleyeSUI.iconCache`, injected as innerHTML. Three icon types: models, categories, UI.
 - **State persistence:** All state saved to `localStorage` under key `styleyes_v1_state`. Validated on load to prevent injection.
-- **Event delegation:** Grid/carousel clicks, stack removes, and category buttons use event delegation with `closest()` for robust handling of nested elements.
-
----
-
-## Verification Protocol
-
-Run the best available checks **before every commit**:
-
-1. **Format / lint / typecheck** (when applicable)
-2. **Unit tests** — `npm test`
-3. **Integration / e2e tests** (when present)
-4. **Build step** (if a build exists)
-
-For static-file-only changes: markdown lint, link checks, build/docs generation, verify version consistency, asset paths referenced in README, and that `npm test` passes.
-
-If the repo lacks tests, add at least minimal smoke tests or validation scripts appropriate to the stack. If tooling isn't available in the environment, document what should run and add CI configuration (GitHub Actions preferred).
-
-## CI Requirements
-
-- Maintain GitHub Actions so lint / typecheck / test / build run on every PR and `main` push.
-- Do not merge if CI fails.
-- If CI is missing, create it as part of the first meaningful change.
-
-## Commit & PR Hygiene
-
-- **Conventional Commits**: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`
-- Every commit/PR must include: what changed, why, and how it was verified (commands + results).
-- Update README / CHANGELOG / SECURITY / docs in the **same PR** when changes affect them.
-- If you fix a bug, add a test that would have caught it (or explain why not).
-
-## CI/CD Workflows
-
-| Workflow | File | Trigger | Purpose |
-|----------|------|---------|---------|
-| CI | `ci.yml` | Push to `main`, all PRs | Runs `npm test` validation |
-| GitHub Pages | `deploy-pages.yml` | Push to `main`, manual | Validates then deploys static files to GitHub Pages |
-| Vercel | `deploy-vercel.yml` | Push to `main`, all PRs | Preview deploys on PRs, production deploy on `main` |
-
-**Vercel secrets required** (set in GitHub repo settings):
-- `VERCEL_TOKEN` — Vercel API token
-- `VERCEL_ORG_ID` — Vercel organization/team ID
-- `VERCEL_PROJECT_ID` — Vercel project ID
-
-All deployment workflows run validation (`npm test`) before deploying. Do not merge if CI fails.
-
----
-
-## Repository Completeness
-
-Keep these files accurate and current. Update them alongside code changes — not as an afterthought.
-
-### README.md
-- Product name + short description
-- Features list
-- Tech stack (languages / frameworks / tools)
-- Setup / Install / Run / Build / Test commands
-- Environment variables documented (via `.env.example`)
-- Architecture / folder structure overview (when non-trivial)
-- Deployment notes (if relevant)
-- Usage examples (CLI / API / UI)
-- Product imagery with alt text (when applicable)
-
-### Required Repo Files
-- `LICENSE` (or explicit "All Rights Reserved" documentation)
-- `CHANGELOG.md` — [Keep a Changelog](https://keepachangelog.com/) style. Every meaningful change gets an entry. Include upgrade notes for breaking changes.
-- `SECURITY.md` — How to report vulnerabilities.
-- `.editorconfig`, `.gitignore`
-- `.env.example` (if env vars exist)
-- `CODE_OF_CONDUCT.md` (recommended)
-
-### Task Tracking Directory
-- `tasks/todo.md` — Active task plan with checkable items. Updated per session.
-- `tasks/lessons.md` — Accumulated patterns from corrections and mistakes. Reviewed at session start.
-- Create the `tasks/` directory as part of repo scaffolding if it does not exist.
-
-### Dependency & Asset Management
-- Keep lockfiles up to date (`package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` / `requirements.lock`, etc.)
-- If assets carry different licenses, document them (`ASSETS_LICENSE.md` or in README).
-- Maintain a file manifest (`/docs/MANIFEST.md`) when useful for describing major artifacts and generated files.
-
----
+- **Event delegation:** Grid/carousel clicks, stack removes, and category buttons use event delegation with `closest()`.
 
 ## Version Management
 
@@ -257,22 +244,23 @@ The `npm test` validation script checks version consistency across these files.
 - **White Balance controls** are mutually exclusive — adding one removes any existing WB control from the stack.
 - **Max limits:** 5 styles, 3 controls, 50 history entries (enforced in `StyleyeSConfig`).
 
----
+-----
+
+## Workflow Orchestration
+
+**Plan mode:** Default to planning before execution on non-trivial tasks. For complex work, write the plan to a file first.
+
+**Subagents:** For complex multi-file tasks, delegate via Task tool. Lead agent coordinates; subagents inherit this CLAUDE.md.
+
+**Self-improvement:** Append lessons to `tasks/lessons.md` after non-trivial debugging. Track deferred work in `tasks/todo.md` with issue links. Review lessons at session start.
+
+**Autonomous bug fixing:** When given a bug report, just fix it. Point at logs, errors, failing tests — then resolve them. Zero context switching required from the user.
+
+-----
 
 ## Quality Gates
 
 - Keep dependencies minimal. This project intentionally has zero runtime dependencies.
-- Prefer strict types and strict linting where feasible.
 - Prefer consistent patterns over cleverness.
 - Every meaningful change gets a CHANGELOG entry.
-- When working with AI tool-use patterns (Skills, MCP servers, etc.), align with the platform's best-practice guidance: tool boundaries, safety, reliability, evals, prompt/tool separation.
-- A `tasks/lessons.md` that grows smarter with every session.
-
-## What Good Looks Like
-
-- Clean, well-structured code.
-- Focused diffs with clear rationale.
-- Docs that stay in sync with reality.
-- Tests that prevent regressions.
-- CI that catches problems before humans do.
 - A `tasks/lessons.md` that grows smarter with every session.

--- a/README.md
+++ b/README.md
@@ -8,15 +8,17 @@
 
 Craft rich, descriptive prompts for AI image generators with curated art styles, lighting controls, and intelligent prompt optimization.
 
-[![GitHub](https://img.shields.io/badge/GitHub-StyleyeS-FF6B35?style=for-the-badge&logo=github)](https://github.com/SeanVasey/StyleyeS)
+[![CI](https://img.shields.io/github/actions/workflow/status/SeanVasey/StyleyeS/ci.yml?branch=main&style=for-the-badge&label=CI)](https://github.com/SeanVasey/StyleyeS/actions/workflows/ci.yml)
+[![Pages](https://img.shields.io/github/actions/workflow/status/SeanVasey/StyleyeS/deploy-pages.yml?branch=main&style=for-the-badge&label=Pages)](https://seanvasey.github.io/StyleyeS)
+[![Vercel](https://img.shields.io/github/actions/workflow/status/SeanVasey/StyleyeS/deploy-vercel.yml?branch=main&style=for-the-badge&label=Vercel)](https://github.com/SeanVasey/StyleyeS/actions/workflows/deploy-vercel.yml)
+[![Version](https://img.shields.io/badge/Version-2.1.1-00D4AA?style=for-the-badge)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-Apache%202.0-DC2F5A?style=for-the-badge)](LICENSE)
 [![PWA](https://img.shields.io/badge/PWA-Ready-9B4DCA?style=for-the-badge)](manifest.json)
-[![Version](https://img.shields.io/badge/Version-2.1.1-00D4AA?style=for-the-badge)](CHANGELOG.md)
-[![CI](https://img.shields.io/github/actions/workflow/status/SeanVasey/StyleyeS/ci.yml?branch=main&style=for-the-badge&label=CI)](https://github.com/SeanVasey/StyleyeS/actions/workflows/ci.yml)
-[![Pages](https://img.shields.io/github/actions/workflow/status/SeanVasey/StyleyeS/deploy-pages.yml?branch=main&style=for-the-badge&label=Pages)](https://github.com/SeanVasey/StyleyeS/actions/workflows/deploy-pages.yml)
-[![Vercel](https://img.shields.io/github/actions/workflow/status/SeanVasey/StyleyeS/deploy-vercel.yml?branch=main&style=for-the-badge&label=Vercel)](https://github.com/SeanVasey/StyleyeS/actions/workflows/deploy-vercel.yml)
+[![Zero Dependencies](https://img.shields.io/badge/Dependencies-0-FF6B35?style=for-the-badge)](package.json)
 
-[Features](#-features) • [Getting Started](#-getting-started) • [Usage](#-usage) • [Project Structure](#-project-structure) • [Contributing](#-contributing)
+**[Live Demo](https://seanvasey.github.io/StyleyeS)**
+
+[Features](#-features) • [Getting Started](#-getting-started) • [Usage](#-usage) • [Architecture](#-technical-details) • [Contributing](#-contributing)
 
 </div>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,9 +8,9 @@ StyleyeS is committed to maintaining the security and integrity of our image gen
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 2.1.x   | :white_check_mark: |
 | 2.0.x   | :white_check_mark: |
-| 1.8.x   | :white_check_mark: |
-| < 1.8   | :x:                |
+| < 2.0   | :x:                |
 
 ## Security Practices
 


### PR DESCRIPTION
- Restructured CLAUDE.md with streamlined standards: consolidated security
  (input/data, client-side hardening, supply chain, production hardening),
  updated workflow orchestration, and added README spec requirements
- README: added live demo link, zero-dependencies badge, reordered badges
  to lead with CI/deploy status over static labels
- SECURITY.md: updated supported versions to 2.1.x/2.0.x, dropped < 2.0
- CHANGELOG: documented all changes in Unreleased section

Verified: npm test passes (version consistency + required files)

https://claude.ai/code/session_01MoCq86uFk7icrBPXKCFVjo